### PR TITLE
Use unions in Java, simplify record batch deserialization, change C++ to use Message type

### DIFF
--- a/cpp/src/arrow/ipc/metadata-internal.cc
+++ b/cpp/src/arrow/ipc/metadata-internal.cc
@@ -320,23 +320,10 @@ Status MessageBuilder::SetRecordBatch(int32_t length, int64_t body_length,
 Status WriteRecordBatchMetadata(int32_t length, int64_t body_length,
     const std::vector<flatbuf::FieldNode>& nodes,
     const std::vector<flatbuf::Buffer>& buffers, std::shared_ptr<Buffer>* out) {
-  flatbuffers::FlatBufferBuilder fbb;
-
-  auto batch = flatbuf::CreateRecordBatch(
-      fbb, length, fbb.CreateVectorOfStructs(nodes), fbb.CreateVectorOfStructs(buffers));
-
-  fbb.Finish(batch);
-
-  int32_t size = fbb.GetSize();
-
-  auto result = std::make_shared<PoolBuffer>();
-  RETURN_NOT_OK(result->Resize(size));
-
-  uint8_t* dst = result->mutable_data();
-  memcpy(dst, fbb.GetBufferPointer(), size);
-
-  *out = result;
-  return Status::OK();
+  MessageBuilder builder;
+  RETURN_NOT_OK(builder.SetRecordBatch(length, body_length, nodes, buffers));
+  RETURN_NOT_OK(builder.Finish());
+  return builder.GetBuffer(out);
 }
 
 Status MessageBuilder::Finish() {

--- a/format/File.fbs
+++ b/format/File.fbs
@@ -43,7 +43,7 @@ struct Block {
 
   /// Length of the data (this is aligned so there can be a gap between this and
   /// the metatdata).
-  bodyLength: int;
+  bodyLength: long;
 }
 
 root_type Footer;

--- a/java/vector/src/main/java/org/apache/arrow/vector/file/ArrowBlock.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/file/ArrowBlock.java
@@ -26,9 +26,9 @@ public class ArrowBlock implements FBSerializable {
 
   private final long offset;
   private final int metadataLength;
-  private final int bodyLength;
+  private final long bodyLength;
 
-  public ArrowBlock(long offset, int metadataLength, int bodyLength) {
+  public ArrowBlock(long offset, int metadataLength, long bodyLength) {
     super();
     this.offset = offset;
     this.metadataLength = metadataLength;
@@ -43,7 +43,7 @@ public class ArrowBlock implements FBSerializable {
     return metadataLength;
   }
 
-  public int getBodyLength() {
+  public long getBodyLength() {
     return bodyLength;
   }
 
@@ -56,7 +56,7 @@ public class ArrowBlock implements FBSerializable {
   public int hashCode() {
     final int prime = 31;
     int result = 1;
-    result = prime * result + bodyLength;
+    result = prime * result + (int) (bodyLength ^ (bodyLength >>> 32));
     result = prime * result + metadataLength;
     result = prime * result + (int) (offset ^ (offset >>> 32));
     return result;

--- a/java/vector/src/main/java/org/apache/arrow/vector/stream/MessageSerializer.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/stream/MessageSerializer.java
@@ -169,8 +169,6 @@ public class MessageSerializer {
    */
   public static ArrowRecordBatch deserializeRecordBatch(ReadChannel in, ArrowBlock block,
       BufferAllocator alloc) throws IOException {
-    long readPosition = in.getCurrentPositiion();
-
     // Metadata length contains integer prefix plus byte padding
     long totalLen = block.getMetadataLength() + block.getBodyLength();
 


### PR DESCRIPTION
This makes the integration tests pass again. Since individual vectors can contain 2B elements, the size of record batches can technically exceed INT32_MAX

Part of https://github.com/apache/arrow/pull/292